### PR TITLE
fix: add types to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,16 @@
     "lib"
   ],
   "exports": {
-    "import": "./lib/esm/index.browser.js",
-    "default": "./lib/cjs/index.js"
+    ".": {
+      "types": "./lib/types/index.d.ts",
+      "browser": "./lib/esm/index.browser.js",
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
+    },
+    "./browser": {
+      "types": "./lib/types/index.d.ts",
+      "default": "./lib/esm/index.browser.js"
+    }
   },
   "scripts": {
     "build": "pnpm build:cjs && pnpm build:esm",


### PR DESCRIPTION
This PR adds types for the new exports.

It also adds a specific `"browser"` export, and a fallback to `/browser` for anyone using this with build tools that don't support the `browser` condition.