### PR TITLE
fix: correct rejection sampling threshold in uid generation

### DIFF
--- a/src/uid.ts
+++ b/src/uid.ts
@@ -25,7 +25,7 @@ export const generateUidFunction =
         let rand;
         for (let i = 0; i < buf.length; i++) {
           rand = buf[i];
-          while (rand > 248) {
+          while (rand > 247) {
             try {
               rand = randomBytes(1)[0];
             } catch (err) {


### PR DESCRIPTION
## Summary

Fix an **off-by-one error** in the rejection sampling algorithm that causes character `"A"` to appear ~25% more often than any other character.

### Finding: Rejection Sampling Bias (Low)

**File:** `src/uid.ts`, line 28

**Issue:** The rejection threshold is `rand > 248`, but should be `rand >= 248` (or equivalently `rand > 247`).

- Character set size: 62 chars
- `256 % 62 = 8` → values 0-247 (248 values) are evenly divisible by 62 = **4 mappings per char**
- Value 248 also passes the filter (`248 > 248` is `false`) and maps to index `248 % 62 = 0` → `"A"`
- So `"A"` gets **5 mappings** vs 4 for all other characters = **25% relative bias**

### Fix
Changed `while (rand > 248)` to `while (rand > 247)`.

### Verification
- ✅ All existing tests pass (`npm test`)
- ✅ 62-char charset: `256 - (256 % 62) = 248`, correct threshold is `>= 248` or `> 247`

### Related
- CWE-330: Use of Insufficiently Random Values

---

🔒 **Security Note for Vercel Security Team**

This PR fixes a cryptographic bias in uid generation. This finding may be eligible for the **Vercel Open Source Bug Bounty Program** (Tier 1: $200–$10,000).
Ref: https://hackerone.com/vercel-open-source